### PR TITLE
Initial implementation of audio playback + media ocnflict fix

### DIFF
--- a/components/audio.js
+++ b/components/audio.js
@@ -1,0 +1,30 @@
+import { log } from "../log";
+import { strip } from "./display";
+import { Base, componentMap } from "./base";
+import { html } from "uhtml";
+import db from "../db";
+
+class Audio extends Base {
+  static defaultProps = {
+    stateName: "$Audio",
+  };
+
+  async playAudio() {
+    const { state } = this.context;
+    const { stateName } = this.props;
+    const fileName = strip(state.get(stateName) || "");
+    log("play audio");
+    (await db.getAudio(fileName)).play();
+  }
+
+  template() {
+    const { stateName } = this.props;
+    const { state } = this.context;
+    if (state.hasBeenUpdated(stateName)) {
+      this.playAudio();
+    }
+    return html``;
+  }
+}
+
+componentMap.addMap("audio", Audio);

--- a/components/base.js
+++ b/components/base.js
@@ -213,7 +213,7 @@ export function toDesign(tree) {
 
 class Page extends Base {
   static defaultProps = {};
-  static allowedChildren = ["stack", "modal dialog", "speech"];
+  static allowedChildren = ["stack", "modal dialog", "speech", "audio"];
 
   template() {
     return html`${this.children.map((child) => child.template())}`;

--- a/components/content.js
+++ b/components/content.js
@@ -186,6 +186,28 @@ export class Content extends Base {
         Reload local sheet
       </button>
       <span>${this.sheetMessage}</span>
+
+      <h2>Load audio clips</h2>
+      <label for="audio">Upload audio clips: </label>
+      <input
+        id="audio"
+        type="file"
+        multiple
+        accept=".mp3,.wav,.ogg"
+        onchange=${async (/** @type {InputEventWithTarget} */ event) => {
+          const input = /** @type {HTMLInputElement} */ (event.currentTarget);
+          if (!input || !input.files || !input.files.length) {
+            return;
+          }
+          for (const file of input.files) {
+            if (file && file.type.startsWith("audio/")) {
+              await db.addMedia(file, file.name);
+            }
+          }
+          this.context.state.update();
+        }}
+      />
+
       <h2>Load images</h2>
       <label for="images">Upload images: </label>
       <input
@@ -200,7 +222,7 @@ export class Content extends Base {
           }
           for (const file of input.files) {
             if (file && file.type.startsWith("image/")) {
-              await db.addImage(file, file.name);
+              await db.addMedia(file, file.name);
               // ask any live images with this name to refresh
               for (const img of document.querySelectorAll(
                 `img[dbsrc="${file.name}"]`
@@ -212,7 +234,7 @@ export class Content extends Base {
           this.context.state.update();
         }}
       />
-      <h2>Currently loaded images</h2>
+      <h2>Currently loaded media files</h2>
       <ol style="column-count: 3">
         ${(/** @type {HTMLElement} */ comment) => {
           /* I'm experimenting here. db.listImages() is asynchronous but I don't want
@@ -224,7 +246,7 @@ export class Content extends Base {
            * the asynchronous content when it becomes available being careful to keep
            * the comment node in the output. It seems to work, is it safe?
            */
-          db.listImages().then((names) => {
+          db.listMedia().then((names) => {
             const list = names.map((name) => html`<li>${name}</li>`);
             render(comment.parentNode, html`${comment}${list}`);
           });

--- a/components/img-db.js
+++ b/components/img-db.js
@@ -34,7 +34,7 @@ export class imgFromDb extends HTMLImageElement {
   async updateSrcFromDb(url) {
     // if it contains a slash treat it like an external url
     // if not, fetch it from the db
-    if (url.indexOf("/") < 0) url = await db.getImageURL(url);
+    if (url.indexOf("/") < 0) url = await db.getMediaURL(url);
     this.src = url;
   }
 }

--- a/components/index.js
+++ b/components/index.js
@@ -10,6 +10,7 @@ import "./vsd";
 import "./button";
 import "./monitor";
 import "./speech";
+import "./audio";
 import "./help";
 
 export { assemble };


### PR DESCRIPTION
Initial implementation of audio playback support. Works just like how speech does, except it fetches audio clips from the db.

Media conflicts between designs has been fixed by creating one store, "media," where the key for each entry is an array containing the design name first and the file name second.