### PR TITLE
Menu bug fixes

### DIFF
--- a/components/access/cues/index.js
+++ b/components/access/cues/index.js
@@ -30,7 +30,9 @@ export class CueList extends DesignerTabPanel {
 
   renderCss() {
     const result = this.children.map((child) => child.renderCss());
-    result.push(this.defaultCue.renderCss({ Key: "DefaultCue" }));
+    if (this.children.length > 0) {
+      result.push(this.defaultCue.renderCss({ Key: "DefaultCue" }));
+    }
     return result;
   }
 

--- a/components/toolbar.js
+++ b/components/toolbar.js
@@ -1,6 +1,7 @@
 import { TreeBase } from "./treebase";
 import { Stack } from "./stack";
 import { PatternGroup } from "components/access/pattern";
+import { Page } from "components/page";
 
 import "css/toolbar.css";
 import db from "app/db";
@@ -231,8 +232,16 @@ function getEditMenuItems() {
     }),
     new MenuItem("Copy", async () => {
       const component = Globals.designer.selectedComponent;
-      const json = JSON.stringify(component.toObject());
-      navigator.clipboard.writeText(json);
+      if (component) {
+        const parent = component.parent;
+        if (
+          !(component instanceof Page) &&
+          !(parent instanceof DesignerTabControl)
+        ) {
+          const json = JSON.stringify(component.toObject());
+          navigator.clipboard.writeText(json);
+        }
+      }
     }),
     new MenuItem("Cut", async () => {
       const component = Globals.designer.selectedComponent;
@@ -332,18 +341,18 @@ export class ToolBar extends TreeBase {
           <li>
             <label for="designName">Name: </label>
             ${hinted(
-              html` <input
+      html` <input
                 id="designName"
                 type="text"
                 .value=${db.designName}
                 .size=${Math.max(db.designName.length, 12)}
                 onchange=${(event) =>
-                  db
-                    .renameDesign(event.target.value)
-                    .then(() => (window.location.hash = db.designName))}
+          db
+            .renameDesign(event.target.value)
+            .then(() => (window.location.hash = db.designName))}
               />`,
-              "N"
-            )}
+      "N"
+    )}
           </li>
           <li>
             ${hinted(this.fileMenu.render(), "F")}

--- a/components/toolbar.js
+++ b/components/toolbar.js
@@ -11,6 +11,7 @@ import { callAfterRender } from "app/render";
 import { fileOpen } from "browser-fs-access";
 import pleaseWait from "components/wait";
 import { DB } from "app/db";
+import { DesignerTabControl } from "./tabcontrol";
 
 const friendlyNamesMap = {
   ActionCondition: "Condition",
@@ -163,7 +164,8 @@ function getPanelMenuItems(type) {
     type !== "move" && // no moves
     parent &&
     !(component instanceof Stack && parent instanceof Stack) &&
-    !(component instanceof PatternGroup && parent instanceof PatternGroup)
+    !(component instanceof PatternGroup && parent instanceof PatternGroup) &&
+    !(parent instanceof DesignerTabControl)
   ) {
     const parentItems = getComponentMenuItems(parent, type, itemCallback);
     if (menuItems.length && parentItems.length) {


### PR DESCRIPTION
This pull request addresses the following bugs:

- showing DesignerTabControl menu items (e.g, being allowed to add a new panel to the designer itself). The pull request code adds "!(parent instanceof DesignerTabControl)" to the list of conditions for adding parent actions to the menu.
- inability to render the page if CueList is empty. The pull request code will not call renderCss on this.defaultCue if CueList is empty, since there is no default cue.

It also incorporates the following 'fix':

- Instead of copying invalid components (e.g. Page, the panels), the pull request code also retains the last valid component to paste.

Notes:

- There are some minor whitespace edits that came from auto-formatting whitespace.
- I don't think that any of the changes should have affected the ability of focus to go to the PatternList panel, but I did notice that with this code, some OSDPI files wherein the PatternList was emptied prior to the changes do not have the lastFocused attribute set to anything, which makes the Add menu be empty (instead of allowing one to add a Pattern). However, OSDPI files with PatternLists that were emptied while testing with this code did not exhibit this issue.

Thank you!